### PR TITLE
Add `faraday-multipart` to gemspec file

### DIFF
--- a/elevenlabs.gemspec
+++ b/elevenlabs.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.5"
 
   spec.add_dependency "faraday", "~> 2.0"
+  spec.add_dependency "faraday-multipart", "~> 1.1"
   spec.metadata["source_code_uri"] = 'https://github.com/ktamulonis/elevenlabs'
 end
 


### PR DESCRIPTION
Thanks for creating this gem! :heart: 

I ran into this error when adding it:
```
There was an error while trying to load the gem 'elevenlabs'. (Bundler::GemRequireError)
Gem Load Error is: cannot load such file -- faraday/multipart
```

A workaround would be to include the gem `faraday-multipart` in my project, but I think it makes sense to add it to the gem itself too.