### PR TITLE
Add create dialogue

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,13 @@ Designed voices cannot be used for TTS until they are created in your account.
 
 If the voice is not immediately available for TTS, wait a few seconds or check its status via client.get_voice(voice_id) until it’s "active".
 
+10. Create a multi-speaker dialogue
+```ruby
+inputs = [{text: "It smells like updog in here", voice_id: "TX3LPaxmHKxFdv7VOQHJ"}, {text: "What's updog?", voice_id: "RILOU7YmBhvwJGDGjNmP"}, {text: "Not much, you?", voice_id: "TX3LPaxmHKxFdv7VOQHJ"}]
+
+audio_data = client.text_to_dialogue(inputs)
+File.open("what's updog.mp3", "wb") { |f| f.write(audio_data) }
+```
 
 ---
 

--- a/lib/elevenlabs/client.rb
+++ b/lib/elevenlabs/client.rb
@@ -89,6 +89,47 @@ module Elevenlabs
     end
 
     #####################################################
+    #              Text-to-Dialogue                     #
+    #    (POST /v1/text-to-dialogue)                    #
+    #####################################################
+
+    # Converts a list of text and voice ID pairs into speech (dialogue) and returns audio.
+    # Documentation: https://elevenlabs.io/docs/api-reference/text-to-dialogue/convert
+    #
+    # @param [Array[Objects]] inputs - A list of dialogue inputs, each containing text and a voice ID which will be converted into speech
+    #   :text => String
+    #   :voice_id => String
+    # @param [String] model_id - optional Identifier of the model to be used
+    # @param [Hash] settings - optinal Settings controlling the dialogue generation
+    #   :stability => double - 0.0 = Creative, 0.5 = Natural, 1.0 = Robust
+    #   :use_speaker_boost => boolean
+    # @param [Integer] seed - optional Best effort to sample deterministically.
+    #
+    # @return [String] The binary audio data (usually an MP3).
+    def text_to_dialogue(inputs, model_id = nil, settings = {}, seed = nil)
+      endpoint = "/v1/text-to-dialogue"
+      request_body = {}.tap do |r|
+        r[:inputs] = inputs
+        r[:model_id] = model_id if model_id
+        r[:settings] = settings unless settings.empty?
+        r[:seed] = seed if seed
+      end
+
+      headers = default_headers
+      headers["Accept"] = "audio/mpeg"
+
+      response = @connection.post(endpoint) do |req|
+        req.headers = headers
+        req.body = request_body.to_json
+      end
+
+      # Returns raw binary data (often MP3)
+      response.body
+    rescue Faraday::ClientError => e
+      handle_error(e)
+    end
+
+    #####################################################
     #                  Design a Voice                   #
     #      (POST /v1/text-to-voice/design)              #
     #####################################################


### PR DESCRIPTION
Fix #3
Add support to create multi-speaker dialogues

Steps to test:
1. Checkout branch and open irb with local gem: `bundle exec irb -r elevenlabs`
2. Create client: `c = Elevenlabs::Client.new(api_key: "apikey")`
3. Create dialogue inputs: `inputs = [{text: "It smells like updog in here", voice_id: "TX3LP
axmHKxFdv7VOQHJ"}, {text: "What's updog?", voice_id: "RILOU7YmBhvwJGDGjNmP"}, {text: "Not much, you?", voice_id: "TX3LPaxmHKxFdv7VOQHJ"}]`
4. Create dialogue: `a = c.text_to_dialogue(inputs)`
5. Save file: `File.open("/tmp/updog.mp3", "wb") { |f| f.write(a) }`
6. Open file `/tmp/updog.mp3`